### PR TITLE
Update License Section to be controlled by .github repository (Not a license change)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,0 @@
-# License
-
-This repository is licensed using a modified version of the BSD 3-Clause License.
-The license is available for review [here](https://docs.encoredigitalgroup.com/LicenseTerms/).


### PR DESCRIPTION
This PR does not change the license of the code, it moves control of the GitHub License section to the `.github` repo for easy link management to the Encore Digital Group documentation site.